### PR TITLE
chore(security): ignore RUSTSEC-2026-0206 (rustybuzz unmaintained)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -99,4 +99,17 @@ ignore = [
     # project's Wl/atspi/zbus-crate stack to move first.
     "RUSTSEC-2026-0194", # quick-xml: quadratic run time on duplicate-attribute-name check
     "RUSTSEC-2026-0195", # quick-xml: unbounded namespace-declaration allocation in NsReader
+
+    # rustybuzz - unmaintained (status: unmaintained, not an active vulnerability).
+    # Upstream declared the crate unmaintained on 2026-07-11 and published no patched
+    # release (`patched = []`), so there is no version to upgrade to. It is reachable only
+    # through the Slint text stack: rustybuzz 0.20.1 <- usvg 0.45.1 <- resvg 0.45.1 <-
+    # i-slint-compiler (build time, via slint-build and slint-macros) and i-slint-core
+    # (runtime). Confirmed with `cargo tree -i rustybuzz --target x86_64-pc-windows-msvc`,
+    # which shows both paths on the shipped target. The advisory's suggested replacement is
+    # `harfrust`; adopting it requires resvg and slint to migrate first, which EasyHDR cannot
+    # do unilaterally. This is the same upstream text stack as RUSTSEC-2026-0192 (ttf-parser)
+    # above, whose rationale already lists rustybuzz as one of its consumers. There is no
+    # CVE-class vulnerability today, so the immediate security risk is nil.
+    "RUSTSEC-2026-0206", # rustybuzz: crate is unmaintained by upstream (harfbuzz/rustybuzz#166)
 ] # end of audit ignore list

--- a/deny.toml
+++ b/deny.toml
@@ -121,6 +121,19 @@ ignore = [
     # project's Wl/atspi/zbus-crate stack to move first.
     "RUSTSEC-2026-0194", # quick-xml: quadratic run time on duplicate-attribute-name check
     "RUSTSEC-2026-0195", # quick-xml: unbounded namespace-declaration allocation in NsReader
+
+    # rustybuzz - unmaintained (status: unmaintained, not an active vulnerability).
+    # Upstream declared the crate unmaintained on 2026-07-11 and published no patched
+    # release (`patched = []`), so there is no version to upgrade to. It is reachable only
+    # through the Slint text stack: rustybuzz 0.20.1 <- usvg 0.45.1 <- resvg 0.45.1 <-
+    # i-slint-compiler (build time, via slint-build and slint-macros) and i-slint-core
+    # (runtime). Confirmed with `cargo tree -i rustybuzz --target x86_64-pc-windows-msvc`,
+    # which shows both paths on the shipped target. The advisory's suggested replacement is
+    # `harfrust`; adopting it requires resvg and slint to migrate first, which EasyHDR cannot
+    # do unilaterally. This is the same upstream text stack as RUSTSEC-2026-0192 (ttf-parser)
+    # above, whose rationale already lists rustybuzz as one of its consumers. There is no
+    # CVE-class vulnerability today, so the immediate security risk is nil.
+    "RUSTSEC-2026-0206", # rustybuzz: crate is unmaintained by upstream (harfbuzz/rustybuzz#166)
 ] # end of advisories.ignore
 
 [licenses]


### PR DESCRIPTION
## Summary

`RUSTSEC-2026-0206` (rustybuzz marked unmaintained upstream on 2026-07-11) is currently failing `cargo deny check advisories` on **`main` itself** as well as on every open PR. The advisory has `patched = []`, so there is no version to upgrade to.

## Why ignore rather than upgrade

rustybuzz 0.20.1 is reachable only through the Slint text stack:

```
rustybuzz 0.20.1 <- usvg 0.45.1 <- resvg 0.45.1 <- i-slint-compiler (build) / i-slint-core (runtime)
```

Verified with `cargo tree -i rustybuzz --target x86_64-pc-windows-msvc` — both paths are present on the shipped target. The advisory's suggested replacement (`harfrust`) has to be adopted by resvg and slint first; EasyHDR cannot move it unilaterally.

This is the same upstream text stack as the existing `RUSTSEC-2026-0192` (ttf-parser) entry, whose rationale already names rustybuzz as one of its consumers. The advisory is `informational = "unmaintained"` — not a CVE-class vulnerability.

## Changes

Added the ignore to **both** `deny.toml` and `.cargo/audit.toml`, per the repo convention that advisory ignores are maintained in both files with a justification comment.

## Verification

```
$ cargo deny check
advisories ok, bans ok, licenses ok, sources ok
```

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a justified ignore for the informational, unpatched rustybuzz maintenance advisory to both repository security-check configurations.
- Adds `RUSTSEC-2026-0206` to the cargo-audit ignore list.
- Adds the same advisory to the cargo-deny ignore list.
- Documents the dependency path, lack of a patched release, and upstream migration constraint.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because both narrowly scoped advisory ignores are valid, synchronized, and convention-compliant.

The change suppresses only the specified informational rustybuzz advisory in the two configurations that consume advisory ignores, with no identified build, runtime, or security regression.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .cargo/audit.toml | Adds the advisory-specific ignore using valid syntax and the repository’s required justification convention. |
| deny.toml | Adds the matching cargo-deny ignore for an unmaintained transitive dependency, without suppressing other advisories. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(security): ignore RUSTSEC-2026-020..."](https://github.com/engels74/easyhdr/commit/07b58616c9fbac83ee28fcc8790fed230dfc519c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55844108)</sub>

<!-- /greptile_comment -->