### PR TITLE
fix(deps): bump event-listener to 5.4.2 (RUSTSEC-2026-0221)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,11 +1639,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1460,11 +1460,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]


### PR DESCRIPTION
## Summary

Fixes `RUSTSEC-2026-0221` (#120) — `event-listener` 5.4.1 unconditionally implements `Send`/`Sync` for `StackSlot<'_, T>`, allowing a `!Send` tag set via `Event::with_tag` to cross a thread boundary and race in safe code. Classified `unsound`, categories `memory-corruption` / `thread-safety`.

## Why a bump rather than an ignore

The advisory declares:

```toml
[versions]
patched = [">= 5.4.2"]
```

So unlike the `rustybuzz` / `ttf-parser` entries in `deny.toml`, there *is* a fixed release. Nothing in the tree declares a direct dependency on `event-listener`, so no manifest edit is needed — a lockfile bump is sufficient and is the minimal correct fix.

## Exposure

`event-listener` reaches the tree only through the Linux accessibility stack:

```
event-listener <- async-broadcast <- zbus <- atspi / accesskit_unix
               <- accesskit_winit <- i-slint-backend-winit <- slint
```

`cargo tree -i event-listener --target x86_64-pc-windows-msvc` reports **"nothing to print"** — it is not in the shipped Windows build at all. The bump is therefore zero-risk for the release binary and simply keeps dev/CI hosts clean.

## Changes

Applied to both `Cargo.lock` and `fuzz/Cargo.lock` so the two stay in sync (2 lines each: version + checksum; 5.4.2 also drops the `concurrent-queue` dep, still used elsewhere).

## Verification

```
$ cargo metadata --locked                                 # OK
$ cargo metadata --manifest-path fuzz/Cargo.toml --locked # OK
$ cargo deny check
advisories ok, bans ok, licenses ok, sources ok
```

Closes #120